### PR TITLE
NSE-3509 - including new domains as part of the audit with SecOps

### DIFF
--- a/ZIA_DR.pac
+++ b/ZIA_DR.pac
@@ -24,9 +24,9 @@ function FindProxyForURL(url, host)
     localHostOrDomainIs(host, "glxy.com") ||
     localHostOrDomainIs(host, "glxy.net") ||
     localHostOrDomainIs(host, "visionhill.com"))
-    
+
     return "DIRECT";
-  
+
 //ZPA Connectivity is required for Zscaler DR - PRIVATE IP RANGE Belongs to IP
   if (isInNet(host, "100.64.0.0", "255.255.0.0"))
 return "DIRECT";
@@ -48,7 +48,24 @@ return "DIRECT";
  shExpMatch(host, "*.exp-tas.com") ||
  shExpMatch(host, "exp-tas.com") ||
  shExpMatch(host, "*.kraken.com") ||
- shExpMatch(host, "kraken.com")
+ shExpMatch(host, "kraken.com") ||
+
+ // --- Added: gaps identified in top-100 domain review vs. Zscaler global DR safelist ---
+ // Source: dr_pac_recommended.csv (2-important tier, not present in drdb.txt or prior custom allowlist)
+ shExpMatch(host, "mimecastprotect.com") ||
+ shExpMatch(host, "*.mimecastprotect.com") ||
+ shExpMatch(host, "monaeo.com") ||
+ shExpMatch(host, "*.monaeo.com") ||
+ shExpMatch(host, "urbanairship.com") ||
+ shExpMatch(host, "*.urbanairship.com") ||
+ shExpMatch(host, "nextup.ai") ||
+ shExpMatch(host, "*.nextup.ai") ||
+ shExpMatch(host, "cliqtrq.com") ||
+ shExpMatch(host, "*.cliqtrq.com") ||
+ shExpMatch(host, "hsforms.com") ||
+ shExpMatch(host, "*.hsforms.com") ||
+ shExpMatch(host, "namely.com") ||
+ shExpMatch(host, "*.namely.com")
 ) {
  return "DIRECT";
 }


### PR DESCRIPTION
This pull request updates the `ZIA_DR.pac` file to expand the list of domains that are allowed direct access, based on a review of top-100 domains and recommendations from `dr_pac_recommended.csv`. The main change is the addition of several important domains that were previously missing from the allowlist.

**Domain allowlist expansion:**

* Added both root and wildcard entries for the following domains to the direct access allowlist: `mimecastprotect.com`, `monaeo.com`, `urbanairship.com`, `nextup.ai`, `cliqtrq.com`, `hsforms.com`, and `namely.com`, addressing gaps identified in the top-100 domain review and aligning with Zscaler global DR safelist recommendations.