### PR TITLE
NSE-3509 - Fixes to DR Pac file

### DIFF
--- a/ZIA_DR.pac
+++ b/ZIA_DR.pac
@@ -1,73 +1,112 @@
 function FindProxyForURL(url, host)
 {
+
   //
   // Bypass proxy for Galaxy Digital and related domains
-
+  // NOTE: localHostOrDomainIs() does NOT match subdomains - apex + "*." pairs required
+  //
+  if (
+    shExpMatch(host, "contactgfm.com") ||
+    shExpMatch(host, "*.contactgfm.com") ||
+    shExpMatch(host, "g2d2.io") ||
+    shExpMatch(host, "*.g2d2.io") ||
+    shExpMatch(host, "galaxy.app") ||
+    shExpMatch(host, "*.galaxy.app") ||
+    shExpMatch(host, "galaxy.com") ||
+    shExpMatch(host, "*.galaxy.com") ||
+    shExpMatch(host, "galaxydigital.ca") ||
+    shExpMatch(host, "*.galaxydigital.ca") ||
+    shExpMatch(host, "galaxydigital.io") ||
+    shExpMatch(host, "*.galaxydigital.io") ||
+    shExpMatch(host, "galaxydigital.services") ||
+    shExpMatch(host, "*.galaxydigital.services") ||
+    shExpMatch(host, "galaxyfundmanagement.com") ||
+    shExpMatch(host, "*.galaxyfundmanagement.com") ||
+    shExpMatch(host, "galaxyinteractive.io") ||
+    shExpMatch(host, "*.galaxyinteractive.io") ||
+    shExpMatch(host, "galaxyip.com") ||
+    shExpMatch(host, "*.galaxyip.com") ||
+    shExpMatch(host, "galaxy.shop") ||
+    shExpMatch(host, "*.galaxy.shop") ||
+    shExpMatch(host, "galaxytest.io") ||
+    shExpMatch(host, "*.galaxytest.io") ||
+    shExpMatch(host, "gdt.exchange") ||
+    shExpMatch(host, "*.gdt.exchange") ||
+    shExpMatch(host, "gdtexchange.com") ||
+    shExpMatch(host, "*.gdtexchange.com") ||
+    shExpMatch(host, "gdtrading.io") ||
+    shExpMatch(host, "*.gdtrading.io") ||
+    shExpMatch(host, "gfmcryptocademy.com") ||
+    shExpMatch(host, "*.gfmcryptocademy.com") ||
+    shExpMatch(host, "glxy.com") ||
+    shExpMatch(host, "*.glxy.com") ||
+    shExpMatch(host, "glxy.net") ||
+    shExpMatch(host, "*.glxy.net") ||
+    shExpMatch(host, "visionhill.com") ||
+    shExpMatch(host, "*.visionhill.com")
+  ) {
+    return "DIRECT";
+  }
 
   //
-  if (localHostOrDomainIs(host, "contactgfm.com") ||
-    localHostOrDomainIs(host, "g2d2.io") ||
-    localHostOrDomainIs(host, "galaxy.app") ||
-    localHostOrDomainIs(host, "galaxy.com") ||
-    localHostOrDomainIs(host, "galaxydigital.ca") ||
-    localHostOrDomainIs(host, "galaxydigital.io") ||
-    localHostOrDomainIs(host, "galaxydigital.services") ||
-    localHostOrDomainIs(host, "galaxyfundmanagement.com") ||
-    localHostOrDomainIs(host, "galaxyinteractive.io") ||
-    localHostOrDomainIs(host, "galaxyip.com") ||
-    localHostOrDomainIs(host, "galaxy.shop") ||
-    localHostOrDomainIs(host, "galaxytest.io") ||
-    localHostOrDomainIs(host, "gdt.exchange") ||
-    localHostOrDomainIs(host, "gdtexchange.com") ||
-    localHostOrDomainIs(host, "gdtrading.io") ||
-    localHostOrDomainIs(host, "gfmcryptocademy.com") ||
-    localHostOrDomainIs(host, "glxy.com") ||
-    localHostOrDomainIs(host, "glxy.net") ||
-    localHostOrDomainIs(host, "visionhill.com"))
-
+  // ZPA connectivity is required for Zscaler DR - private IP range belongs to ZPA
+  //
+  if (isInNet(host, "100.64.0.0", "255.255.0.0")) {
     return "DIRECT";
+  }
 
-//ZPA Connectivity is required for Zscaler DR - PRIVATE IP RANGE Belongs to IP
-  if (isInNet(host, "100.64.0.0", "255.255.0.0"))
-return "DIRECT";
-
-//Third Party Allowlist for ZIA DR
+  //
+  // ZPA control plane domains - required by Zscaler DR documentation
+  //
   if (
- shExpMatch(host, "usequark.xyz") ||
- shExpMatch(host, "*.usequark.xyz") ||
- shExpMatch(host, "*.netsuite.com") ||
- shExpMatch(host, "netsuite.com") ||
- shExpMatch(host, "*.artemisxyz.com") ||
- shExpMatch(host, "artemisxyz.com") ||
- shExpMatch(host, "*.morpho.org") ||
- shExpMatch(host, "morpho.org") ||
- shExpMatch(host, "*.arbitrum.io") ||
- shExpMatch(host, "arbitrum.io") ||
- shExpMatch(host, "*.gmxinfra.io") ||
- shExpMatch(host, "gmxinfra.io") ||
- shExpMatch(host, "*.exp-tas.com") ||
- shExpMatch(host, "exp-tas.com") ||
- shExpMatch(host, "*.kraken.com") ||
- shExpMatch(host, "kraken.com") ||
+    shExpMatch(host, "zpath.net") ||
+    shExpMatch(host, "*.zpath.net")
+  ) {
+    return "DIRECT";
+  }
 
- // --- Added: gaps identified in top-100 domain review vs. Zscaler global DR safelist ---
- // Source: dr_pac_recommended.csv (2-important tier, not present in drdb.txt or prior custom allowlist)
- shExpMatch(host, "mimecastprotect.com") ||
- shExpMatch(host, "*.mimecastprotect.com") ||
- shExpMatch(host, "monaeo.com") ||
- shExpMatch(host, "*.monaeo.com") ||
- shExpMatch(host, "urbanairship.com") ||
- shExpMatch(host, "*.urbanairship.com") ||
- shExpMatch(host, "nextup.ai") ||
- shExpMatch(host, "*.nextup.ai") ||
- shExpMatch(host, "cliqtrq.com") ||
- shExpMatch(host, "*.cliqtrq.com") ||
- shExpMatch(host, "hsforms.com") ||
- shExpMatch(host, "*.hsforms.com") ||
- shExpMatch(host, "namely.com") ||
- shExpMatch(host, "*.namely.com")
-) {
- return "DIRECT";
-}
+  //
+  // Third party allowlist for ZIA DR
+  //
+  if (
+    shExpMatch(host, "usequark.xyz") ||
+    shExpMatch(host, "*.usequark.xyz") ||
+    shExpMatch(host, "netsuite.com") ||
+    shExpMatch(host, "*.netsuite.com") ||
+    shExpMatch(host, "artemisxyz.com") ||
+    shExpMatch(host, "*.artemisxyz.com") ||
+    shExpMatch(host, "morpho.org") ||
+    shExpMatch(host, "*.morpho.org") ||
+    shExpMatch(host, "arbitrum.io") ||
+    shExpMatch(host, "*.arbitrum.io") ||
+    shExpMatch(host, "gmxinfra.io") ||
+    shExpMatch(host, "*.gmxinfra.io") ||
+    shExpMatch(host, "exp-tas.com") ||
+    shExpMatch(host, "*.exp-tas.com") ||
+    shExpMatch(host, "kraken.com") ||
+    shExpMatch(host, "*.kraken.com") ||
+    shExpMatch(host, "haruko.io") ||
+    shExpMatch(host, "*.haruko.io") ||
+
+    // --- Added: gaps identified in top-100 domain review vs. Zscaler global DR safelist ---
+    // Source: dr_pac_recommended.csv (2-important tier, not present in drdb.txt
+    // or prior custom allowlist)
+    shExpMatch(host, "mimecastprotect.com") ||
+    shExpMatch(host, "*.mimecastprotect.com") ||
+    shExpMatch(host, "monaeo.com") ||
+    shExpMatch(host, "*.monaeo.com") ||
+    shExpMatch(host, "urbanairship.com") ||
+    shExpMatch(host, "*.urbanairship.com") ||
+    shExpMatch(host, "nextup.ai") ||
+    shExpMatch(host, "*.nextup.ai") ||
+    shExpMatch(host, "cliqtrq.com") ||
+    shExpMatch(host, "*.cliqtrq.com") ||
+    shExpMatch(host, "hsforms.com") ||
+    shExpMatch(host, "*.hsforms.com") ||
+    shExpMatch(host, "namely.com") ||
+    shExpMatch(host, "*.namely.com")
+  ) {
+    return "DIRECT";
+  }
 
 }

--- a/ZIA_DR.pac
+++ b/ZIA_DR.pac
@@ -109,4 +109,5 @@ function FindProxyForURL(url, host)
     return "DIRECT";
   }
 
+  return "DIRECT";
 }

--- a/ZIA_DR.pac
+++ b/ZIA_DR.pac
@@ -1,6 +1,6 @@
 function FindProxyForURL(url, host)
 {
-
+  host = host.toLowerCase();
   //
   // Bypass proxy for Galaxy Digital and related domains
   // NOTE: localHostOrDomainIs() does NOT match subdomains - apex + "*." pairs required


### PR DESCRIPTION
This pull request updates the `ZIA_DR.pac` proxy auto-config file to improve how domains are matched for proxy bypass and expands the allowlist for direct connections. The main change is switching from `localHostOrDomainIs` to `shExpMatch` for domain matching, which now properly includes both apex domains and all their subdomains. Additionally, the allowlist has been expanded for Zscaler DR requirements and third-party services.

**Proxy bypass improvements:**

* Replaced all uses of `localHostOrDomainIs` with `shExpMatch` to ensure both apex domains and their subdomains are matched for the Galaxy Digital and related domains, improving coverage and maintainability. (`ZIA_DR.pac`)
* Added support for bypassing the proxy for ZPA control plane domains (`zpath.net` and subdomains), as required by Zscaler DR documentation. (`ZIA_DR.pac`)
* Clarified and reorganized comments for better readability, explaining the need for apex + wildcard pairs and the purpose of each allowlist section. (`ZIA_DR.pac`)

**Third-party allowlist expansion:**

* Updated the third-party allowlist to include both apex domains and subdomains for several services (e.g., `netsuite.com`, `artemisxyz.com`, `morpho.org`,…mended ones + galaxy ones were not matching